### PR TITLE
Add `/d/mysql-set-default` shortcut to explain why the `SetDefault` referential action is no longer supported on `mysql`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -49,7 +49,7 @@
         "destination": "https://www.prisma.io/docs/reference/more/telemetry"
     },
     {
-        "source:" "/d/mysql-set-default",
+        "source": "/d/mysql-set-default",
         "destination": "https://github.com/prisma/prisma/issues/11498#issuecomment-1305571663"
     },
     {


### PR DESCRIPTION
Add temporary `/d/mysql-set-default` link to a [Github comment](https://github.com/prisma/prisma/issues/11498#issuecomment-1305571663). As soon as the new doc page will be ready, the destination link should point to the docs page instead.

Context: https://github.com/prisma/prisma-engines/pull/3363