### PR TITLE
Fix links that are currently marked as unreachable by link checker

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -226,7 +226,7 @@
     },
     {
         "source": "/quickstart",
-        "destination": "https://codeload.github.com/prisma/quickstart/tar.gz/main"
+        "destination": "https://www.prisma.io/docs/getting-started/quickstart"
     },
     {
         "source": "/d/migrate",
@@ -586,7 +586,7 @@
     },
     {
         "source": "/day2021-intro-kr",
-        "destination": "https://www.notion.so/Prisma-Workshop-dada8b3c8aa142d5b0566932e1cdb058"
+        "destination": "https://www.notion.so/prismaio/A-Practical-Introduction-to-Prisma-2021-ccf00a066ef4432caeb03da179e38302"
     },
     {
         "source": "/day2021-intro-es",


### PR DESCRIPTION
Related https://github.com/prisma/pris.ly/issues/59

The Notion links somehow fail when they start with
`https://www.notion.so/prismaio`
but work when using
`https://prismaio.notion.site`