### PR TITLE
Add referential actions' links for warnings handling Postgres and MySQL special cases

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -233,6 +233,10 @@
             "destination": "https://www.prisma.io/docs/concepts/components/prisma-schema/relations/referential-actions#types-of-referential-actions"
         },
         {
+            "source": "/d/relation-mode-indexes",
+            "destination": "https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode#indexes"
+        },
+        {
             "source": "/d/help/next-js-best-practices",
             "destination": "https://www.prisma.io/docs/support/help-articles/nextjs-prisma-client-dev-practices"
         },

--- a/vercel.json
+++ b/vercel.json
@@ -225,6 +225,14 @@
             "destination": "https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode"
         },
         {
+            "source": "/d/postgres-set-null",
+            "destination": "https://www.prisma.io/docs/concepts/components/prisma-schema/relations/referential-actions#types-of-referential-actions"
+        },
+        {
+            "source": "/d/mysql-set-default",
+            "destination": "https://www.prisma.io/docs/concepts/components/prisma-schema/relations/referential-actions#types-of-referential-actions"
+        },
+        {
             "source": "/d/help/next-js-best-practices",
             "destination": "https://www.prisma.io/docs/support/help-articles/nextjs-prisma-client-dev-practices"
         },

--- a/vercel.json
+++ b/vercel.json
@@ -233,7 +233,7 @@
             "destination": "https://www.prisma.io/docs/concepts/components/prisma-schema/relations/referential-actions#types-of-referential-actions"
         },
         {
-            "source": "/d/relation-mode-indexes",
+            "source": "/d/relation-mode-prisma-indexes",
             "destination": "https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode#indexes"
         },
         {


### PR DESCRIPTION
- `/d/postgres-set-null` is used in the warning message added for https://github.com/prisma/prisma-private/issues/198
- `/d/mysql-set-default` is used in the warning message added for https://github.com/prisma/prisma/issues/16259
- `/d/relation-mode-prisma-indexes` is used in the warning message added for https://github.com/prisma/language-tools/issues/992