### PR TITLE
feat: add `/d/system-requirements` link to Prisma's system requirements

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -875,6 +875,10 @@
         {
             "source": "/d/partition-tables",
             "destination": "https://github.com/prisma/prisma/issues/1708"
+        },
+        {
+            "source": "/d/system-requirements",
+            "destination": "https://www.prisma.io/docs/reference/system-requirements"
         }
     ]
 }


### PR DESCRIPTION
`/d/system-requirements` -> https://www.prisma.io/docs/reference/system-requirements

This is used in [this warning message](https://github.com/prisma/prisma/blob/bfbd3ec077596e4554f56ac20a2cde663cef8b3b/packages/engine-core/src/common/errors/utils/handleEngineLoadingErrors.ts#L17-L19).