### PR TITLE
added pulse notion docs to pulse-docs link

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -955,6 +955,10 @@
         {
             "source": "/engine-not-found-tooling-investigation",
             "destination": "https://github.com/prisma/prisma/discussions/19498"
+        },
+        {
+            "source": "/pulse-docs",
+            "destination": "https://www.notion.so/prismaio/Pulse-Docs-in-progress-e515f580710440d2aa06d78842ab25ab?pvs=4"
         }
     ]
 }


### PR DESCRIPTION
The name of the branch is wrong my bad, but its just a short link for the pulse docs so we can link to them in the control-plane and update it in one spot going forward