### PR TITLE
add https://pris.ly/d/cockroachdb-postgresql-provider

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -38,7 +38,7 @@
         },
         {
             "source": "/d/cockroachdb-postgresql-provider",
-            "destination": "https://www.prisma.io/docs//guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-5#cockroachdb-provider-is-now-required-when-connecting-to-a-cockroachdb-database"
+            "destination": "https://www.prisma.io/docs/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-5#cockroachdb-provider-is-now-required-when-connecting-to-a-cockroachdb-database"
         },
         {
             "source": "/d/logging",

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,10 @@
             "destination": "https://www.prisma.io/docs/concepts/database-connectors/cockroachdb"
         },
         {
+            "source": "/d/cockroachdb-postgresql-provider",
+            "destination": "https://www.prisma.io/docs//guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-5#cockroachdb-provider-is-now-required-when-connecting-to-a-cockroachdb-database"
+        },
+        {
             "source": "/d/logging",
             "destination": "https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/logging"
         },


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/226

Based on https://docs-git-jharrell-issue4848-prisma.vercel.app/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-5#cockroachdb-provider-is-now-required-when-connecting-to-a-cockroachdb-database